### PR TITLE
Included time variable in the tag condition

### DIFF
--- a/azure-deploy.json
+++ b/azure-deploy.json
@@ -126,25 +126,25 @@
                                                                         {
                                                                             "equals": [
                                                                                 "@items('For_each_virtual_machine')?['tags']?['AutoOff']",
-                                                                                "@addMinutes(utcNow(), 1, 'HH:mm')"
+                                                                                "addMinutes(formatDateTime(variables('Time'), 'o'), 1, 'HH:mm')"
                                                                             ]
                                                                         },
                                                                         {
                                                                             "equals": [
                                                                                 "@items('For_each_virtual_machine')?['tags']?['AutoOff']",
-                                                                                "@addMinutes(utcNow(), 2, 'HH:mm')"
+                                                                                "addMinutes(formatDateTime(variables('Time'), 'o'), 2, 'HH:mm')"
                                                                             ]
                                                                         },
                                                                         {
                                                                             "equals": [
                                                                                 "@items('For_each_virtual_machine')?['tags']?['AutoOff']",
-                                                                                "@subtractFromTime(utcNow(), 1, 'Minute', 'HH:mm')"
+                                                                                "subtractFromTime(formatDateTime(variables('Time'), 'o'), 1, 'Minute', 'HH:mm')"
                                                                             ]
                                                                         },
                                                                         {
                                                                             "equals": [
                                                                                 "@items('For_each_virtual_machine')?['tags']?['AutoOff']",
-                                                                                "@subtractFromTime(utcNow(), 2, 'Minute', 'HH:mm')"
+                                                                                "subtractFromTime(formatDateTime(variables('Time'), 'o'), 2, 'Minute', 'HH:mm')"
                                                                             ]
                                                                         }
                                                                     ]
@@ -164,25 +164,25 @@
                                                             {
                                                                 "equals": [
                                                                     "@items('For_each_virtual_machine')?['tags']?['AutoOn']",
-                                                                    "@addMinutes(utcNow(), 1, 'HH:mm')"
+                                                                    "addMinutes(formatDateTime(variables('Time'), 'o'), 1, 'HH:mm')"
                                                                 ]
                                                             },
                                                             {
                                                                 "equals": [
                                                                     "@items('For_each_virtual_machine')?['tags']?['AutoOn']",
-                                                                    "@addMinutes(utcNow(), 2, 'HH:mm')"
+                                                                    "addMinutes(formatDateTime(variables('Time'), 'o'), 2, 'HH:mm')"
                                                                 ]
                                                             },
                                                             {
                                                                 "equals": [
                                                                     "@items('For_each_virtual_machine')?['tags']?['AutoOn']",
-                                                                    "@subtractFromTime(utcNow(), 1, 'Minute', 'HH:mm')"
+                                                                    "subtractFromTime(formatDateTime(variables('Time'), 'o'), 1, 'Minute', 'HH:mm')"
                                                                 ]
                                                             },
                                                             {
                                                                 "equals": [
                                                                     "@items('For_each_virtual_machine')?['tags']?['AutoOn']",
-                                                                    "@subtractFromTime(utcNow(), 2, 'Minute', 'HH:mm')"
+                                                                    "subtractFromTime(formatDateTime(variables('Time'), 'o'), 2, 'Minute', 'HH:mm')"
                                                                 ]
                                                             }
                                                         ]

--- a/azure-deploy.json
+++ b/azure-deploy.json
@@ -126,25 +126,25 @@
                                                                         {
                                                                             "equals": [
                                                                                 "@items('For_each_virtual_machine')?['tags']?['AutoOff']",
-                                                                                "addMinutes(formatDateTime(variables('Time'), 'o'), 1, 'HH:mm')"
+                                                                                "@addMinutes(formatDateTime(variables('Time'), 'o'), 1, 'HH:mm')"
                                                                             ]
                                                                         },
                                                                         {
                                                                             "equals": [
                                                                                 "@items('For_each_virtual_machine')?['tags']?['AutoOff']",
-                                                                                "addMinutes(formatDateTime(variables('Time'), 'o'), 2, 'HH:mm')"
+                                                                                "@addMinutes(formatDateTime(variables('Time'), 'o'), 2, 'HH:mm')"
                                                                             ]
                                                                         },
                                                                         {
                                                                             "equals": [
                                                                                 "@items('For_each_virtual_machine')?['tags']?['AutoOff']",
-                                                                                "subtractFromTime(formatDateTime(variables('Time'), 'o'), 1, 'Minute', 'HH:mm')"
+                                                                                "@subtractFromTime(formatDateTime(variables('Time'), 'o'), 1, 'Minute', 'HH:mm')"
                                                                             ]
                                                                         },
                                                                         {
                                                                             "equals": [
                                                                                 "@items('For_each_virtual_machine')?['tags']?['AutoOff']",
-                                                                                "subtractFromTime(formatDateTime(variables('Time'), 'o'), 2, 'Minute', 'HH:mm')"
+                                                                                "@subtractFromTime(formatDateTime(variables('Time'), 'o'), 2, 'Minute', 'HH:mm')"
                                                                             ]
                                                                         }
                                                                     ]
@@ -164,25 +164,25 @@
                                                             {
                                                                 "equals": [
                                                                     "@items('For_each_virtual_machine')?['tags']?['AutoOn']",
-                                                                    "addMinutes(formatDateTime(variables('Time'), 'o'), 1, 'HH:mm')"
+                                                                    "@addMinutes(formatDateTime(variables('Time'), 'o'), 1, 'HH:mm')"
                                                                 ]
                                                             },
                                                             {
                                                                 "equals": [
                                                                     "@items('For_each_virtual_machine')?['tags']?['AutoOn']",
-                                                                    "addMinutes(formatDateTime(variables('Time'), 'o'), 2, 'HH:mm')"
+                                                                    "@addMinutes(formatDateTime(variables('Time'), 'o'), 2, 'HH:mm')"
                                                                 ]
                                                             },
                                                             {
                                                                 "equals": [
                                                                     "@items('For_each_virtual_machine')?['tags']?['AutoOn']",
-                                                                    "subtractFromTime(formatDateTime(variables('Time'), 'o'), 1, 'Minute', 'HH:mm')"
+                                                                    "@subtractFromTime(formatDateTime(variables('Time'), 'o'), 1, 'Minute', 'HH:mm')"
                                                                 ]
                                                             },
                                                             {
                                                                 "equals": [
                                                                     "@items('For_each_virtual_machine')?['tags']?['AutoOn']",
-                                                                    "subtractFromTime(formatDateTime(variables('Time'), 'o'), 2, 'Minute', 'HH:mm')"
+                                                                    "@subtractFromTime(formatDateTime(variables('Time'), 'o'), 2, 'Minute', 'HH:mm')"
                                                                 ]
                                                             }
                                                         ]


### PR DESCRIPTION
Added in the time variable to the AutoOn / AutoOff tag condition when adding and subtracting from time. This ensures consistency throughout and fixes the bug where the LogicApp would trigger slightly early/